### PR TITLE
fix: date accept string from keyboard

### DIFF
--- a/src/constants/country-list.ts
+++ b/src/constants/country-list.ts
@@ -7,6 +7,5 @@ export const countyList: Country[] = [
   { name: 'Germany', code: 'DE' },
   { name: 'France', code: 'FR' },
   { name: 'Spain', code: 'ES' },
-  { name: 'Sweden', code: 'SE' },
   { name: 'Italy', code: 'IT' },
 ];

--- a/src/utils/registration-schema.ts
+++ b/src/utils/registration-schema.ts
@@ -14,15 +14,25 @@ export const addressSchema = z.object({
     .regex(/^\p{L}+$/u, {
       message: 'City must contain only letters (no spaces, apostrophes, hyphens, numbers, or special characters)',
     }),
-  postalCode: z.string().regex(/^(\d{6}|\d{5}-\d{4}|\d{4}\s\d{3})$/, {
-    message: 'Invalid postal code format (e.g., 000000, 12345-6789, or 1234 567)',
+  postalCode: z.string().regex(/^\d{5}$/, {
+    message: 'Invalid postal code format (e.g., 28013)',
   }),
   country: z.string().min(1, { message: 'Country must be selected' }),
 });
 
 export const registrationSchema = z.object({
-  firstName: z.string().min(1, { message: 'First name must be at least 1 characters long' }),
-  lastName: z.string().min(1, { message: 'Last name must be at least 1 characters long' }),
+  firstName: z
+    .string()
+    .min(1, { message: 'First name must be at least 1 characters long' })
+    .regex(/^\p{L}+$/u, {
+      message: 'First name must contain only letters',
+    }),
+  lastName: z
+    .string()
+    .min(1, { message: 'Last name must be at least 1 characters long' })
+    .regex(/^\p{L}+$/u, {
+      message: 'Last name must contain only letters',
+    }),
   email: z
     .string()
     .regex(/^[a-zA-Z0-9@._-]+$/, {
@@ -43,12 +53,8 @@ export const registrationSchema = z.object({
     })
     .regex(/[0-9]/, { message: 'Password must contain at least one number' }),
 
-  dateOfBirth: z.date().refine(
-    (date) => {
-      return date <= thirteenYearsAgo;
-    },
-    {
-      message: 'Must be at least 13 years old',
-    }
+  dateOfBirth: z.preprocess(
+    (val) => (typeof val === 'string' ? new Date(val) : val),
+    z.date().refine((date) => date <= thirteenYearsAgo, { message: 'Must be at least 13 years old' })
   ),
 });


### PR DESCRIPTION
# Pull Request Template

`Number of Sprint:` 2

`Task:` fix cross check review

`Issues:`
- First name: Must contain at least one character and no special characters or numbers - Можно вводить цифры
- Last name: Must contain at least one character and no special characters or numbers - Можно вводить цифры
- Date of birth: A valid date input ensuring the user is above a certain age (e.g., 13 years old or older) - Сломанная валидация, если вводить что то вручную пишет "Expected date, received string"
- Postal code: Must follow the format for the country (e.g., 12345 or A1B 2C3 for the U.S. and Canada, respectively) - Валидация одинаковая для всех стран, хотя там разные форматы


Deploy: [link](https://reginamos.github.io/e-commerce/release-sprint-2/)
