### PR TITLE
feat: add clear cart confirmation window

### DIFF
--- a/src/components/ConfirmModalComponent.vue
+++ b/src/components/ConfirmModalComponent.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+
+interface Props {
+  modelValue: boolean;
+  title?: string;
+  message?: string;
+}
+
+const props = defineProps<Props>();
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void;
+  (e: 'confirm'): void;
+  (e: 'cancel'): void;
+}>();
+
+const dialogVisible = ref(props.modelValue);
+
+watch(
+  () => props.modelValue,
+  (newVal) => {
+    dialogVisible.value = newVal;
+  }
+);
+
+watch(dialogVisible, (val) => {
+  if (val !== props.modelValue) {
+    emit('update:modelValue', val);
+  }
+});
+
+const handleConfirm = () => {
+  emit('confirm');
+  dialogVisible.value = false;
+};
+
+const handleCancel = () => {
+  emit('cancel');
+  dialogVisible.value = false;
+};
+</script>
+
+<template>
+  <v-dialog v-model="dialogVisible" max-width="500px">
+    <v-card
+      prepend-icon="mdi-cart-outline"
+      :title="title || 'Confirm Action'"
+      :text="message || 'Are you sure you want to proceed?'"
+    >
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn color="primary" variant="text" @click="handleCancel"> Cancel </v-btn>
+        <v-btn color="error" variant="text" @click="handleConfirm"> Confirm </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>

--- a/src/utils/confirmation-modal.ts
+++ b/src/utils/confirmation-modal.ts
@@ -1,0 +1,25 @@
+import { ref } from 'vue';
+
+export function useConfirmationModal() {
+  const isModalOpen = ref(false);
+  const modalTitle = ref('Confirm Action');
+  const modalMessage = ref('Are you sure you want to proceed?');
+
+  const showModal = (title?: string, message?: string) => {
+    if (title) modalTitle.value = title;
+    if (message) modalMessage.value = message;
+    isModalOpen.value = true;
+  };
+
+  const hideModal = () => {
+    isModalOpen.value = false;
+  };
+
+  return {
+    isModalOpen,
+    modalTitle,
+    modalMessage,
+    showModal,
+    hideModal,
+  };
+}

--- a/src/views/CartView.vue
+++ b/src/views/CartView.vue
@@ -13,10 +13,13 @@ import {
   applyDiscountCode,
   activeCart,
 } from '../services/carts-service';
+import { useConfirmationModal } from '../utils/confirmation-modal';
+import ConfirmModalComponent from '../components/ConfirmModalComponent.vue';
 
 const isLoading = ref(false);
 const promoCode = ref('');
 const isPromoLoading = ref(false);
+const { isModalOpen, showModal } = useConfirmationModal();
 
 const toaster = inject<{ show: (message: string, color?: string) => void }>('toaster');
 
@@ -89,6 +92,10 @@ const handleRemove = (lineItemId: string) =>
   updateCart<[string]>(removeCartItem, 'Item removed successfully', lineItemId);
 
 const handleClearCart = () => updateCart<[]>(clearCart, 'Cart cleared successfully');
+
+const handleConfirm = () => {
+  showModal('Clear Cart', 'Are you sure you want to remove all items from your cart?');
+};
 </script>
 
 <template>
@@ -112,7 +119,13 @@ const handleClearCart = () => updateCart<[]>(clearCart, 'Cart cleared successful
         <v-divider class="my-4" />
 
         <div class="d-flex justify-space-between align-center">
-          <v-btn color="error" variant="outlined" @click="handleClearCart">Clear Cart</v-btn>
+          <v-btn color="error" variant="outlined" @click="handleConfirm">Clear Cart</v-btn>
+          <ConfirmModalComponent
+            v-model="isModalOpen"
+            title="Clear Cart"
+            message="Are you sure you want to remove all items from your cart?"
+            @confirm="handleClearCart"
+          />
 
           <div class="text-h6">
             Total:


### PR DESCRIPTION
# Pull Request Template

`Number of Sprint:` 4

`Task:` Confirmation modal

`Issues:`

- [✅] `RSS-ECOMM-4_18` | A confirmation prompt appears when the "Clear Shopping Cart" button is clicked 

`Tests:` - none

`Description:` Add a confirmation modal window to clear a cart.

## Links

Task: [RSS-ECOMM-4_18](https://github.com/rolling-scopes-school/tasks/blob/master/tasks/eCommerce-Application/Sprints/Sprint4/RSS-ECOMM-4_18.md)

Github: [link](https://github.com/ReginaMos/e-commerce)

Deploy: [link](https://reginamos.github.io/e-commerce/release-sprint-4)
